### PR TITLE
Changes for nl-compiler

### DIFF
--- a/examples/lut.rs
+++ b/examples/lut.rs
@@ -57,6 +57,22 @@ impl Instantiable for Lut {
         }
     }
 
+    fn set_parameter(&mut self, id: &Identifier, val: Parameter) -> Option<Parameter> {
+        if !self.has_parameter(id) {
+            return None;
+        }
+
+        let old = Some(Parameter::BitVec(self.lookup_table.clone()));
+
+        if let Parameter::BitVec(bv) = val {
+            self.lookup_table = bv;
+        } else {
+            panic!("Invalid parameter type for INIT");
+        }
+
+        old
+    }
+
     fn parameters(&self) -> impl Iterator<Item = (Identifier, Parameter)> {
         std::iter::once((
             Identifier::new("INIT".to_string()),

--- a/examples/variants.rs
+++ b/examples/variants.rs
@@ -37,6 +37,10 @@ impl Instantiable for Gate {
         None
     }
 
+    fn set_parameter(&mut self, _id: &Identifier, _val: Parameter) -> Option<Parameter> {
+        None
+    }
+
     fn parameters(&self) -> impl Iterator<Item = (Identifier, Parameter)> {
         std::iter::empty()
     }

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -58,6 +58,7 @@ impl std::fmt::Display for Attribute {
     }
 }
 
+#[derive(Debug, Clone)]
 /// A dedicated type to parameters for instantiables
 pub enum Parameter {
     /// An integer parameter

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -256,6 +256,9 @@ pub trait Instantiable: Clone {
     /// Returns the parameter value for the given key, if it exists.
     fn get_parameter(&self, id: &Identifier) -> Option<Parameter>;
 
+    /// Returns the old parameter value for the given key, if it existed.
+    fn set_parameter(&mut self, id: &Identifier, val: Parameter) -> Option<Parameter>;
+
     /// Returns an iterator over the parameters of the primitive.
     fn parameters(&self) -> impl Iterator<Item = (Identifier, Parameter)>;
 

--- a/src/netlist.rs
+++ b/src/netlist.rs
@@ -864,7 +864,7 @@ where
     I: Instantiable,
 {
     /// The name of the netlist
-    name: String,
+    name: RefCell<String>,
     /// The list of objects in the netlist, such as inputs, modules, and primitives
     objects: RefCell<Vec<NetRefT<I>>>,
     /// The list of operands that point to objects which are outputs
@@ -1100,7 +1100,7 @@ where
     /// Creates a new netlist with the given name
     pub fn new(name: String) -> Rc<Self> {
         Rc::new(Self {
-            name,
+            name: RefCell::new(name),
             objects: RefCell::new(Vec::new()),
             outputs: RefCell::new(HashMap::new()),
         })
@@ -1325,13 +1325,16 @@ where
     I: Instantiable,
 {
     /// Returns the name of the netlist module
-    pub fn get_name(&self) -> &str {
-        &self.name
+    pub fn get_name(&self) -> Ref<String> {
+        self.name.borrow()
     }
 
     /// Sets the name of the netlist module
-    pub fn set_name(&mut self, name: String) {
-        self.name = name;
+    /// # Panics
+    ///
+    /// Panics if the module name cannot be borrowed mutably.
+    pub fn set_name(&self, name: String) {
+        *self.name.borrow_mut() = name;
     }
 
     /// Iterates over the input ports of the netlist.
@@ -1882,7 +1885,7 @@ where
         let objects = self.objects.borrow();
         let outputs = self.outputs.borrow();
 
-        writeln!(f, "module {} (", self.name)?;
+        writeln!(f, "module {} (", self.get_name())?;
 
         // Print inputs and outputs
         let level = 2;

--- a/src/netlist.rs
+++ b/src/netlist.rs
@@ -1329,6 +1329,11 @@ where
         &self.name
     }
 
+    /// Sets the name of the netlist module
+    pub fn set_name(&mut self, name: String) {
+        self.name = name;
+    }
+
     /// Iterates over the input ports of the netlist.
     pub fn get_input_ports(&self) -> impl Iterator<Item = Net> {
         self.objects().filter_map(|oref| {

--- a/src/netlist.rs
+++ b/src/netlist.rs
@@ -57,6 +57,10 @@ impl Instantiable for Gate {
         None
     }
 
+    fn set_parameter(&mut self, _id: &Identifier, _val: Parameter) -> Option<Parameter> {
+        None
+    }
+
     fn parameters(&self) -> impl Iterator<Item = (Identifier, Parameter)> {
         std::iter::empty()
     }

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -407,4 +407,6 @@ fn test_simple_example() {
     assert_eq!(netlist.get_output_ports().len(), 1);
     let objects: Vec<_> = netlist.objects().collect();
     assert_eq!(objects.len(), 3); // 2 inputs + 1 gate
+    netlist.set_name("new_name".to_string());
+    assert_eq!(netlist.get_name().clone(), "new_name");
 }

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -402,7 +402,7 @@ fn test_replace_gate() {
 #[test]
 fn test_simple_example() {
     let netlist = get_simple_example();
-    assert_eq!(netlist.get_name(), "example");
+    assert_eq!(netlist.get_name().clone(), "example");
     assert_eq!(netlist.get_input_ports().count(), 2);
     assert_eq!(netlist.get_output_ports().len(), 1);
     let objects: Vec<_> = netlist.objects().collect();

--- a/tests/matches.rs
+++ b/tests/matches.rs
@@ -37,6 +37,10 @@ impl Instantiable for Gate {
         None
     }
 
+    fn set_parameter(&mut self, _id: &Identifier, _val: Parameter) -> Option<Parameter> {
+        None
+    }
+
     fn parameters(&self) -> impl Iterator<Item = (Identifier, Parameter)> {
         std::iter::empty()
     }

--- a/tests/params.rs
+++ b/tests/params.rs
@@ -58,6 +58,22 @@ impl Instantiable for Lut {
         }
     }
 
+    fn set_parameter(&mut self, id: &Identifier, val: Parameter) -> Option<Parameter> {
+        if !self.has_parameter(id) {
+            return None;
+        }
+
+        let old = Some(Parameter::BitVec(self.lookup_table.clone()));
+
+        if let Parameter::BitVec(bv) = val {
+            self.lookup_table = bv;
+        } else {
+            panic!("Invalid parameter type for INIT");
+        }
+
+        old
+    }
+
     fn parameters(&self) -> impl Iterator<Item = (Identifier, Parameter)> {
         std::iter::once((
             Identifier::new("INIT".to_string()),


### PR DESCRIPTION
- Add `set_parameter()` to Instantiable interface
- Allow for updating name of netlist with `set_name()`. The module name is behind a RefCell now.