### PR TITLE
Critical points returns all the outputs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "safety-net"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -200,21 +200,21 @@ where
     }
 
     /// Returns the most critical endpoints in the circuit
-    pub fn get_critical_points(&self) -> impl IntoIterator<Item = &NetRef<I>> {
+    pub fn get_critical_points(&self) -> impl IntoIterator<Item = DrivenNet<I>> {
         let mut v = self.critical_ends.iter().collect::<Vec<_>>();
         v.sort_by_key(|(d, _)| *d);
-        v.into_iter().map(|(_, n)| n)
+        v.into_iter().flat_map(|(_, n)| n.outputs())
     }
 
     /// Builds the most critical path
-    pub fn build_critical_path(&self) -> Option<Vec<NetRef<I>>> {
+    pub fn build_critical_path(&self) -> Option<Vec<DrivenNet<I>>> {
         let mut path = Vec::new();
-        let mut current = self.get_critical_points().into_iter().next()?.clone();
-        while let Some(crit) = self.critical_par.get(&current) {
+        let mut current = self.get_critical_points().into_iter().next()?;
+        while let Some(crit) = self.critical_par.get(&current.clone().unwrap()) {
             path.push(current.clone());
             current = self
                 ._netlist
-                .get_driver(current, crit.get_input_num())
+                .get_driver(current.unwrap(), crit.get_input_num())
                 .unwrap();
         }
         path.push(current);
@@ -274,7 +274,7 @@ where
 
             for i in 0..node.get_num_input_ports() {
                 let driver = match netlist.get_driver(node.clone(), i) {
-                    Some(d) => d,
+                    Some(d) => d.unwrap(),
                     None => {
                         is_undefined = true;
                         continue;
@@ -363,7 +363,7 @@ where
                     }
 
                     let r = compute(
-                        driver,
+                        driver.unwrap(),
                         netlist,
                         &mut results,
                         &mut critical_par,

--- a/src/netlist.rs
+++ b/src/netlist.rs
@@ -1481,10 +1481,13 @@ where
     ///
     /// Panics if `index` is out of bounds
     /// The `netref` does not belong to this netlist
-    pub fn get_driver(&self, netref: NetRef<I>, index: usize) -> Option<NetRef<I>> {
+    pub fn get_driver(&self, netref: NetRef<I>, index: usize) -> Option<DrivenNet<I>> {
         self.belongs(&netref);
         let op = netref.unwrap().borrow().operands[index]?;
-        Some(NetRef::wrap(self.index_weak(&op.root()).clone()))
+        Some(DrivenNet::new(
+            op.secondary(),
+            NetRef::wrap(self.index_weak(&op.root()).clone()),
+        ))
     }
 
     /// Set an added object as a top-level output with a specific name.

--- a/tests/topo.rs
+++ b/tests/topo.rs
@@ -186,8 +186,8 @@ fn test_comb_depth_dag_shared_subgraph() {
 
     let p = depth_info.build_critical_path().unwrap();
     assert!(p.len() == 2);
-    assert_eq!(p[0], or_node);
-    assert_eq!(p[1], and);
+    assert_eq!(p[0], or_node.into());
+    assert_eq!(p[1], and.into());
 }
 
 #[test]


### PR DESCRIPTION
The fact that `compute()` inside takes in a NetRef instead of DrivenNet is sloppy. But the function should work fine as well as the memoization.